### PR TITLE
Use Markdown on PyPi; closes #74

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@ VERSION = "0.4.2"
 HERE = os.path.abspath(os.path.dirname(__file__))
 
 # Get the long description from the README file.
-# Convert to rst with: pandoc --from=markdown --to=rst README.md -o README.rst.
-with open(os.path.join(HERE, "README.rst"), encoding="utf-8") as f:
+with open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
@@ -19,6 +18,7 @@ setup(
     version=VERSION,
     description="Application to perform curation of neuroscientific literature.",
     long_description=long_description,
+    long_description_content_type='text/markdown',
     keywords="neuroscience annotation curation literature modeling parameters",
     url="https://github.com/BlueBrain/neurocurator",
     author="Christian O'Reilly, Pierre-Alexandre Fonta",


### PR DESCRIPTION
Use the `long_description_content_type` arg in `setup()` to render the
readme with Markdown. Closes #74. Hold off on merging this until the new `wheel` is released (pypa/wheel#232, not sure when the release is coming); before then only `sdist`s will work with Markdown.